### PR TITLE
Parse style negative margins

### DIFF
--- a/dist/ui-bootstrap-tpls.js
+++ b/dist/ui-bootstrap-tpls.js
@@ -2165,7 +2165,8 @@ angular.module('ui.bootstrap.position', [])
        */
       parseStyle: function(value) {
         value = parseFloat(value);
-        return isFinite(value) ? value : 0;
+        // Math.abs to consider negative margins
+        return isFinite(value) ? Math.abs(value) : 0;
       },
 
       /**

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -52,7 +52,8 @@ angular.module('ui.bootstrap.position', [])
        */
       parseStyle: function(value) {
         value = parseFloat(value);
-        return isFinite(value) ? value : 0;
+        // Math.abs to consider negative margins
+        return isFinite(value) ? Math.abs(value) : 0;
       },
 
       /**


### PR DESCRIPTION
**Description**
This ensures tooltips don't flicker on edge pixels by allowing the CSS to define negative margins.

For example:
```
.bs-popover-top,
.bs-tooltip-top {
    margin-top: -1px;
}
.bs-popover-right,
.bs-tooltip-right {
    margin-right: -1px;
}
.bs-popover-bottom,
.bs-tooltip-bottom {
    margin-bottom: -1px;
}
.bs-popover-left,
.bs-tooltip-left {
    margin-left: -1px;
}
```

**Changes**
- Use `Math.abs()` to get a positive value when dealing with negative style properties. This allows for negative margins to be additive for left+right positioning.